### PR TITLE
Fix typo in README: 'recieve' → 'receive'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) and follow our [Code of Conduct](
 
 ## What to work on
 
-- Issues labeled `good first issue`, `help wanted`, or `hacktoberfest`.
+- Issues labeled `good first issue`, `help wanted` or `hacktoberfest`.
 
 ## License
 


### PR DESCRIPTION
Fixed a small spelling typo in the README.

- Removed "comma" after the word 'help wanted' in line 21